### PR TITLE
Add H3 1K prompt curation as a reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ by [BeatAPI](https://beatapi.io).
 **[中文说明](./README.zh-CN.md)** ·
 **[Contribute a prompt](https://github.com/BeatAPI/awesome-minimax-h3-prompts/issues/new?template=prompt.yml)**
 
+## Reference
+
+- [minimax-h3-1000-prompts](https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts) — curated index of the MiniMax H3 1K prompt dataset: 3-field prompt anatomy, 10 hand-picked reusable prompts, and an H3 vs. peer model comparison. Interactive atlas of all 1,000 clips at [neta.art H3 1000 Prompt List](https://neta.art/use-cases/en/h3-1000-prompt-list).
+
 ## Prompt gallery
 
 <!-- GENERATED_VIDEO_GALLERY_START -->


### PR DESCRIPTION
Hello! Thank you for putting together this H3 prompt gallery — the WebM examples and creator attribution are a really nice touch.

This PR adds a small "Reference" section linking a curated index of the MiniMax H3 1K prompt dataset — 3-field prompt anatomy, 10 hand-picked reusable prompts, and an H3 vs. peer model comparison. It's a handy starting point when the gallery doesn't yet cover the exact style you need.

- Curated repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts
- Interactive atlas of all 1,000 clips: https://neta.art/use-cases/en/h3-1000-prompt-list

The underlying dataset is credited as [ostris/minimax_h3_1k](https://huggingface.co/datasets/ostris/minimax_h3_1k) on Hugging Face — 1,000 text prompts with matching 768p videos.

Happy to adjust the wording or placement to better fit the gallery. Thank you!