### PR TITLE
Fix generated README footer validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,11 @@ rights and context.
 Approval is editorial, not automatic. Maintainers may edit formatting while
 preserving meaning and attribution.
 
+The English README is generated from `<!-- GENERATED_VIDEO_GALLERY_START -->`
+through the end of the file. Do not edit that generated section directly;
+update `prompts/catalog.json` or `scripts/build-readme.mjs`, then run
+`npm run readme:build`.
+
 ## Takedown and corrections
 
 Open an issue titled `Takedown: <entry slug>` or email `support@beatapi.io`.

--- a/scripts/build-readme.mjs
+++ b/scripts/build-readme.mjs
@@ -231,6 +231,18 @@ ${entries.slice(0, featuredCount).map((entry, index) => renderEntry(entry, index
 
 ${endMarker}
 
+## More from BeatAPI
+
+- [depth-video-studio](https://github.com/BeatAPI/depth-video-studio) — turn any video into depth, pose, and 478-point face motion-control inputs, 100% in-browser
+- [deepseek-harness-visual-handbook](https://github.com/BeatAPI/deepseek-harness-visual-handbook) — a 103-page source-locked visual guide to DeepSeek Harness
+- [codex-deepseek-worker](https://github.com/BeatAPI/codex-deepseek-worker) — run DeepSeek V4 Flash/Pro as native Codex workers
+- [awesome-readme-studio](https://github.com/BeatAPI/awesome-readme-studio) — an Agent Skill for beautiful, truthful READMEs
+- [awesome-seedance-2-5-prompts](https://github.com/BeatAPI/awesome-seedance-2-5-prompts) — the Seedance 2.5 edition of this prompt catalog
+
+Official BeatAPI API integrations: [beatapi-examples](https://github.com/BeatAPI/beatapi-examples) · [beatapi-cli](https://github.com/BeatAPI/beatapi-cli) · [beatapi-skill](https://github.com/BeatAPI/beatapi-skill) · [beatapi-codex-plugin](https://github.com/BeatAPI/beatapi-codex-plugin)
+
+---
+
 ## Contributing
 
 Use the [prompt submission form](https://github.com/BeatAPI/awesome-minimax-h3-prompts/issues/new?template=prompt.yml)


### PR DESCRIPTION
## Summary

- keep the existing BeatAPI footer inside the README generator output
- document that the English README is generated from the gallery marker through EOF

## Validation

- `npm test`
- `git diff --check`
- Codex Security diff scan: no findings